### PR TITLE
fix(initiative): missing default initiative

### DIFF
--- a/system.json
+++ b/system.json
@@ -66,6 +66,7 @@
   "gridUnits": "ft",
   "primaryTokenAttribute": "health",
   "secondaryTokenAttribute": "stress",
+  "initiative": "1d10",
   "url": "https://github.com/pwatson100/alienrpg",
   "manifest": "https://github.com/pwatson100/alienrpg/releases/latest/download/system.json",
   "download": "https://github.com/pwatson100/alienrpg/releases//latest/download/master.zip",


### PR DESCRIPTION
I have experienced some crashes in the Combat Tracker. Using the debugger, I found that the `game.system.data.initiative` in line 31810 of foundry.js is undefined. In this situation, the Roll class cannot create a roll for the initiative.