### PR TITLE
fix(Manifest): system.json manifest address

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           files: 'system.json'
         env:
           version: ${{github.event.release.tag_name}}
-          manifest: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.json
+          manifest: https://raw.githubusercontent.com/pwatson100/alienrpg/master/system.json
           download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/master.zip
 
       # create a zip file with all files required by the module to add to the release


### PR DESCRIPTION
This should fix the update problem we have when trying to update the game system in the Foundry client.

Explanation: When a new update is released, the Foundry client can see it, but it cannot install it. It's because the system.json file on our computer has a manifest address actually pointing to the older version, with older references to the system version number and download address.