### PR TITLE
some enhancements and bugfixes for your consideration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+--- THIS REPOSITORY IS A FORK --- ITS NOT EVEN UNOFFICIAL ---
+The comments below are from the original pwatson100/alienrpg repository it was forked from.
+
 [![foundry-shield-066]][foundry-url] [![foundry-shield-078]][foundry-url] [![All Release Downloads](https://img.shields.io/github/downloads/pwatson100/alienrpg/total.svg)]()
 
 # Alien RPG System

--- a/css/alienrpg.css
+++ b/css/alienrpg.css
@@ -458,6 +458,17 @@ button:focus {
   align-items: center;
 }
 
+.grid-2col-border {
+  display: grid;
+  grid-column: span 2;
+  grid-template-columns: 1fr 1fr;
+  border-color: var(--aliengreen);
+  padding: 0;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .grid-3col {
   grid-column: span 3 / span 3;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -1725,11 +1736,18 @@ button:focus {
   text-align: center;
 }
 
+.alienrpg .inputtext {
+  color: inherit;
+  background-color: #000;
+  
+}
+
+
 .alienrpg .textbox {
   color: inherit;
-  justify-items: center;
+  padding: 5px;
+  margin: 5px 5px 5px 5px; 
   background-color: #000;
-  width: 180px;
 }
 
 .alienrpg .textbox1 {

--- a/module/YZEDiceRoller.js
+++ b/module/YZEDiceRoller.js
@@ -173,47 +173,31 @@ export class yze {
     // *******************************************************
     // Calulate the total successes and displayas long asit's not a Supply roll.
     // *******************************************************
-    let succEss = game.alienrpg.rollArr.r1Six + game.alienrpg.rollArr.r2Six + game.alienrpg.rollArr.sCount;
+
+   function localizedCountOfSuccesses(sTotal){
+           if (sTotal === 1)
+             return  '1 ' + game.i18n.localize('ALIENRPG.sucess');
+           else
+             return  sTotal + ' ' + game.i18n.localize('ALIENRPG.sucesses');
+   }
+      
 
     if (hostile != 'supply') {
-      if (succEss === 1) {
         chatMessage +=
-          '<div style="color: #6868fc; font-weight: bold; font-size: larger">' + game.i18n.localize('ALIENRPG.youHave') + ' ' + succEss + ' ' + game.i18n.localize('ALIENRPG.sucess') + ' </div>';
-      } else {
-        chatMessage +=
-          '<div style="color: #6868fc; font-weight: bold; font-size: larger">' + game.i18n.localize('ALIENRPG.youHave') + ' ' + succEss + ' ' + game.i18n.localize('ALIENRPG.sucesses') + '</div>';
-      }
+          '<div style="color: #6868fc; font-weight: bold; font-size: larger">' + game.i18n.localize('ALIENRPG.youHave') + ' ' +
+             localizedCountOfSuccesses( game.alienrpg.rollArr.r1Six + game.alienrpg.rollArr.r2Six + game.alienrpg.rollArr.sCount)  + ' </div>';
     }
 
     // *******************************************************
     //  If it's a Push roll and dispaly the total for both rolls.
     // *******************************************************
     if (reRoll && spud && hostile === 'character') {
-      chatMessage += '<hr>';
-      let sTotal = oldRoll + game.alienrpg.rollArr.r1Six + game.alienrpg.rollArr.r2Six;
-      if (sTotal === 1) {
-        chatMessage +=
-          '<div style="color: #6868fc; font-weight: bold; font-size: larger">' +
-          game.i18n.localize('ALIENRPG.followingPush') +
-          '<br>' +
-          game.i18n.localize('ALIENRPG.totalOf') +
-          ' ' +
-          sTotal +
-          ' ' +
-          game.i18n.localize('ALIENRPG.sucess') +
-          ' </div>';
-      } else {
-        chatMessage +=
-          '<div style="color: #6868fc; font-weight: bold; font-size: larger">' +
-          game.i18n.localize('ALIENRPG.followingPush') +
-          '<br> ' +
-          game.i18n.localize('ALIENRPG.totalOf') +
-          ' ' +
-          sTotal +
-          ' ' +
-          game.i18n.localize('ALIENRPG.sucesses') +
-          '</div>';
-      }
+      chatMessage += '<hr>' +
+         '<div style="color: #6868fc; font-weight: bold; font-size: larger">' +
+         game.i18n.localize('ALIENRPG.followingPush') +
+         '<br>' +
+         game.i18n.localize('ALIENRPG.totalOf') +
+       ' '   + localizedCountOfSuccesses(oldRoll + game.alienrpg.rollArr.r1Six + game.alienrpg.rollArr.r2Six) + ' </div>';
     }
 
     // *******************************************************

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -173,6 +173,23 @@ export class alienrpgActorSheet extends ActorSheet {
     // Organize Inventory
     let totalWeight = 0;
     for (let i of items) {
+      if (i.type=='weapon'){
+
+        console.log('alienrpgActorSheet -> Organize Inventory', i); 
+        let ammoweight = 0.25;
+        if(i.data.attributes.class.value=="RPG" || (i.name.includes(" RPG ") || i.name.startsWith("RPG") ||  i.name.endsWith("RPG")))
+        {
+          ammoweight = 0.5; 
+        }
+
+        i.data.attributes.weight.value = i.data.attributes.weight.value || 0;
+        i.totalWeight = i.data.attributes.weight.value + (i.data.attributes.rounds.value * ammoweight);
+        inventory[i.type].items.push(i);
+
+        totalWeight += i.totalWeight;
+     
+      } 
+      else
       if (i.type != 'talent') {
         i.data.attributes.weight.value = i.data.attributes.weight.value || 0;
         i.totalWeight = i.data.attributes.weight.value;

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -342,7 +342,7 @@ export class alienrpgActor extends Actor {
     }
   }
 
-  async checkAndEndPanic(actor){
+   static async checkAndEndPanic(actor){
     
     if(actor.data.type!="character") return;
 
@@ -362,7 +362,15 @@ export class alienrpgActor extends Actor {
     }
 
   };
+    
+   static async  causePanic(actor){
+       actor.update({ 'data.general.panic.value': actor.data.data.general.panic.value + 1 });
+           
+              actor.getActiveTokens().forEach(i => {
+                i.toggleEffect('icons/svg/terror.svg',{active:true,overlay:true });
+              });
 
+    }
 
 
   async rollAbility(actor, dataset) {
@@ -437,11 +445,7 @@ export class alienrpgActor extends Actor {
         let oldPanic = actor.data.data.general.panic.lastRoll;
 
         if (customResults.roll.total >= 7 && actor.data.data.general.panic.value === 0) {
-          actor.update({ 'data.general.panic.value': actor.data.data.general.panic.value + 1 });
-        
-           actor.getActiveTokens().forEach(i => { 
-             i.toggleEffect('icons/svg/terror.svg',{active:true,overlay:true });
-           }); 
+           alienrpgActor.causePanic(actor);
 
         }
 
@@ -534,7 +538,8 @@ export class alienrpgActor extends Actor {
           },
           
           content: chatMessage, 
-          whisper: whispertarget, 
+          whisper: whispertarget,
+          roll:customResults.roll,
           type: CONST.CHAT_MESSAGE_TYPES.ROLL,
           sound: CONFIG.sounds.dice,
           blind 
@@ -752,7 +757,7 @@ export class alienrpgActor extends Actor {
     } else if (event.type === 'contextmenu') {
       newLevel = Math.clamped(level - 1, 0, max);
       if (field[0].name === 'data.general.panic.value') {
-          actor.checkAndEndPanic(actor);
+          alienrpgActor.checkAndEndPanic(actor);
 
       }
     } // Update the field value and save the form

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -342,6 +342,29 @@ export class alienrpgActor extends Actor {
     }
   }
 
+  async checkAndEndPanic(actor){
+    
+    if(actor.data.type!="character") return;
+
+    if( (actor.data.data.general.panic.lastRoll>0)) {
+        actor.update({ 'data.general.panic.lastRoll': 0 });
+   
+        actor.getActiveTokens().forEach(i => { 
+                i.toggleEffect('icons/svg/terror.svg',{active:false,overlay:true });
+           });
+
+        ChatMessage.create({  speaker: { actor: actor.id },
+                              content: "Panic is over",
+                              type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+                           }
+                     );
+
+    }
+
+  };
+
+
+
   async rollAbility(actor, dataset) {
     // console.log("🚀 ~ file: actor.js ~ line 311 ~ alienrpgActor ~ rollAbility ~ actor", actor)
     let label = dataset.label;
@@ -381,8 +404,33 @@ export class alienrpgActor extends Actor {
         let chatMessage = '';
         const table = game.tables.getName('Panic Table');
         // let aStress = actor.getRollData().stress;
-        let aStress = actor.getRollData().stress + parseInt(actor.data.data.header.stress.mod);
-        let modRoll = '1d6' + '+' + parseInt(aStress || 0);
+
+        let rollModifier = parseInt(dataset.mod??0);
+        function panicConditionTitleString(rollModifier) {
+           let title = game.i18n.localize('ALIENRPG.PanicCondition');
+            if(rollModifier>0) {
+               title = title+"+"+rollModifier.toString();
+            } else
+            if(rollModifier<0){
+               title = title+rollModifier.toString();  
+            }
+            return title;
+        };
+
+
+        let aStress = 0;
+
+        if(actor.data.type==='synthetic'){
+          actor.data.data.header.stress=new Object({"mod":"0"});        
+          actor.data.data.general.panic=new Object({"lastRoll":"0","value":"0"});
+          aStress=0;  
+        } else
+        aStress = actor.getRollData().stress +  rollModifier + parseInt(actor.data.data.header.stress.mod);
+     
+        
+        
+        let modRoll = '1d6' + '+' + parseInt(aStress);
+        console.warn('rolling stress',modRoll);
         const roll = new Roll(modRoll);
 
         const customResults = table.roll({ roll });
@@ -390,9 +438,14 @@ export class alienrpgActor extends Actor {
 
         if (customResults.roll.total >= 7 && actor.data.data.general.panic.value === 0) {
           actor.update({ 'data.general.panic.value': actor.data.data.general.panic.value + 1 });
+        
+           actor.getActiveTokens().forEach(i => { 
+             i.toggleEffect('icons/svg/terror.svg',{active:true,overlay:true });
+           }); 
+
         }
 
-        chatMessage += '<h2 style=" color: #f71403; font-weight: bold;" >' + game.i18n.localize('ALIENRPG.PanicCondition') + '</h2>';
+        chatMessage += '<h2 style=" color: #f71403; font-weight: bold;" >' +  panicConditionTitleString(rollModifier)  + '</h2>';
         chatMessage += `<h4><i>${table.data.description}</i></h4>`;
         let mPanic = customResults.roll.total < actor.data.data.general.panic.lastRoll;
 
@@ -423,7 +476,7 @@ export class alienrpgActor extends Actor {
 
           chatMessage += this.morePanic(pCheck);
         } else {
-          actor.update({ 'data.general.panic.lastRoll': customResults.roll.total });
+          if (actor.data.type === 'character') actor.update({ 'data.general.panic.lastRoll': customResults.roll.total });
           pCheck = customResults.roll.total;
           chatMessage += '<h4><i><b>' + game.i18n.localize('ALIENRPG.Roll') + ' ' + `${pCheck}` + ' </b></i></h4>';
           // chatMessage += game.i18n.localize(`ALIENRPG.${customResults.results[0].text}`);
@@ -436,15 +489,58 @@ export class alienrpgActor extends Actor {
         if (trauma) {
           chatMessage += `<h4><b>` + game.i18n.localize('ALIENRPG.PermanantTrauma') + `<i>(` + game.i18n.localize('ALIENRPG.Seepage106') + `) </i></h4></b>`;
         }
+      
+        let rollMode = game.settings.get('core', 'rollMode');
+        let whispertarget = [];
+
+        if (rollMode=='gmroll' || rollMode =='blindroll' ){
+           whispertarget = game.users.entities.filter((u) => u.isGM).map((u) => u._id);
+        }
+        else if (rollMode=='selfroll') {
+           whispertarget = game.users.entities.filter((u) => u.isGM).map((u) => u._id);
+           whispertarget.push(game.user._id);     
+        };
+        
+        let blind=false;  
+        if (rollMode=='blindroll'){
+              blind=true;
+              if (!game.user.isGM){
+                 function SelfMessage(content, sound){
+
+                    let selftarget = [];
+                    selftarget.push(game.user._id);
+                 
+                     ChatMessage.create({  speaker: { actor: actor.id },
+                              content,
+                              whisper:selftarget,
+                              type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+                              sound ,
+                              blind: false}
+                     );
+
+                 };
+
+                   SelfMessage( '<h2 style=" color: #f71403; font-weight: bold;" >' +
+                                        panicConditionTitleString(rollModifier)  +
+                                       " ???</h2>", CONFIG.sounds.dice);
+
+             }
+        }
+
+     
         ChatMessage.create({ 
-          user: game.user._id, 
           speaker: {
             actor: actor.id,
           },
+          
           content: chatMessage, 
-          other: game.users.entities.filter((u) => u.isGM).map((u) => u._id), 
-          type: CONST.CHAT_MESSAGE_TYPES.OTHER 
+          whisper: whispertarget, 
+          type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+          sound: CONFIG.sounds.dice,
+          blind 
+          
         });
+
       }
     }
   }
@@ -601,67 +697,8 @@ export class alienrpgActor extends Actor {
           default: 'one',
           close: (html) => {
             if (confirmed) {
-              let stressMod = parseInt(html.find('[name=stressMod]')[0].value);
-              let chatMessage = '';
-              const table = game.tables.getName('Panic Table');
-              let aStress = actor.getRollData().stress + parseInt(actor.data.data.header.stress.mod);
-              let modRoll = '1d6' + '+' + (parseInt(stressMod || 0) + parseInt(aStress || 0));
-              // console.log('🚀 ~ file: actor.js ~ line 532 ~ alienrpgActor ~ renderTemplate ~ modRoll', modRoll);
-              const roll = new Roll(modRoll);
-
-              const customResults = table.roll({ roll });
-              let oldPanic = actor.data.data.general.panic.lastRoll;
-
-              if (customResults.roll.total >= 7 && actor.data.data.general.panic.value === 0) {
-                actor.update({ 'data.general.panic.value': actor.data.data.general.panic.value + 1 });
-              }
-
-              chatMessage += '<h2 style=" color: #f71403; font-weight: bold;" >' + game.i18n.localize('ALIENRPG.PanicCondition') + '</h2>';
-              chatMessage += `<h4><i>${table.data.description}</i></h4>`;
-              let mPanic = customResults.roll.total < actor.data.data.general.panic.lastRoll;
-
-              let pCheck = oldPanic + 1;
-              if (actor.data.data.general.panic.value && mPanic) {
-                actor.update({ 'data.general.panic.lastRoll': pCheck });
-
-                chatMessage +=
-                  '<h4 style="font-weight: bolder"><i><b>' +
-                  game.i18n.localize('ALIENRPG.Roll') +
-                  ' ' +
-                  `${customResults.roll.total}` +
-                  ' ' +
-                  '<span style="color: #f71403;font-weight: bolder"><i><b>' +
-                  game.i18n.localize('ALIENRPG.MorePanic') +
-                  '</span></b></i></span></h4>';
-
-                chatMessage +=
-                  '<h4><i>' +
-                  game.i18n.localize('ALIENRPG.PCPanicLevel') +
-                  '<b style="color: #f71403;">' +
-                  game.i18n.localize('ALIENRPG.Level') +
-                  ' ' +
-                  `${pCheck}` +
-                  ' ' +
-                  game.i18n.localize('ALIENRPG.Seepage104') +
-                  '</b></i></h4>';
-
-                chatMessage += this.morePanic(pCheck);
-              } else {
-                actor.update({ 'data.general.panic.lastRoll': customResults.roll.total });
-                pCheck = customResults.roll.total;
-                chatMessage += '<h4><i><b>' + game.i18n.localize('ALIENRPG.DialRoll') + ' ' + `${customResults.roll.total}` + ' </b></i></h4>';
-                // chatMessage += game.i18n.localize(`ALIENRPG.${customResults.results[0].text}`);
-                chatMessage += this.morePanic(pCheck);
-                if (customResults.roll.total >= 7) {
-                  chatMessage +=
-                    `<h4 style="color: #f71403;"><i><b>` + game.i18n.localize('ALIENRPG.YouAreAtPanic') + ` <b>` + game.i18n.localize('ALIENRPG.Level') + ` ${customResults.roll.total}</b></i></h4>`;
-                }
-              }
-              let trauma = customResults.roll.total >= 13 || pCheck >= 13;
-              if (trauma) {
-                chatMessage += `<h4><b>` + game.i18n.localize('ALIENRPG.PermanantTrauma') + `<i>(` + game.i18n.localize('ALIENRPG.Seepage106') + `) </i></h4></b>`;
-              }
-              ChatMessage.create({ user: game.user._id, content: chatMessage, other: game.users.entities.filter((u) => u.isGM).map((u) => u._id), type: CONST.CHAT_MESSAGE_TYPES.OTHER });
+                 let mod =  parseInt(html.find('[name=stressMod]')[0].value);
+                 actor.rollAbility(actor,{panicroll:dataset.panicroll,mod });
             }
           },
         }).render(true);
@@ -715,7 +752,8 @@ export class alienrpgActor extends Actor {
     } else if (event.type === 'contextmenu') {
       newLevel = Math.clamped(level - 1, 0, max);
       if (field[0].name === 'data.general.panic.value') {
-        actor.update({ 'data.general.panic.lastRoll': 0 });
+          actor.checkAndEndPanic(actor);
+
       }
     } // Update the field value and save the form
     field.val(newLevel);

--- a/module/alienrpg.js
+++ b/module/alienrpg.js
@@ -15,6 +15,32 @@ import { AlienRPGStressDie } from './alienRPGBaseDice.js';
 import * as migrations from './migration.js';
 import { AlienConfig } from './alienRPGConfig.js';
 
+
+const euclidianDistances = function(segments, options={}) {
+
+  const canvasSize = canvas.dimensions.size;
+  const gridDistance =canvas.scene.data.gridDistance;
+
+  return segments.map(s => {
+    let ray = s.ray;
+
+    // Determine the total distance traveled
+    let x = Math.abs(Math.ceil(ray.dx / canvasSize));
+    let y = Math.abs(Math.ceil(ray.dy / canvasSize));
+
+    return Math.hypot(x, y) * gridDistance;
+  }
+
+);
+};
+
+Hooks.on("canvasInit", function() {
+
+  SquareGrid.prototype.measureDistances = euclidianDistances;
+
+});
+
+
 Hooks.once('init', async function () {
   console.warn(`Initializing Alien RPG`);
   game.alienrpg = {
@@ -312,12 +338,12 @@ Hooks.on('renderChatMessage', (message, html, data) => {
   html.find('button.alien-Push-button').each((i, li) => {
     // console.warn(li);
     li.addEventListener('click', function (ev) {
-      // console.warn(ev);
+  
       if (ev.target.classList.contains('alien-Push-button')) {
         // do stuff
-        let actor = game.actors.get(ChatMessage.getSpeaker().actor);
+        let actor = game.actors.get(message.data.speaker.actor);
         if (!actor) return ui.notifications.warn(game.i18n.localize('ALIENRPG.NoToken'));
-        let token = game.actors.get(ChatMessage.getSpeaker().token);
+
         let reRoll = true;
         let hostile = actor.data.type;
         let blind = false;

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -176,7 +176,8 @@
               <div class="dots panic ">
                 <input type="hidden" name="data.general.panic.value" data-max="{{data.general.panic.max}}" value="{{{data.general.panic.value}}}" data-dtype="Number">
                 {{#if data.general.panic.value}}
-                <h4 class="click-stat-level resource-label blink" style="color: red;" title="{{ localize 'ALIENRPG.ConButtons'}}" >{{{data.general.panic.icon}}} {{ localize 'ALIENRPG.Panicked'}}
+                <h4 class="click-stat-level resource-label " style="color: red;" title="{{ localize 'ALIENRPG.ConButtons'}}" >{{{data.general.panic.icon}}} {{ localize 'ALIENRPG.Panicked'}}
+                        <input type="text" class="maxboxsize" name="data.general.panic.lastRoll"  value="{{data.general.panic.lastRoll}}" data-dtype="Number">            
                 </h4>
                 {{else}}
                 <h4 class="click-stat-level resource-label " title="{{ localize 'ALIENRPG.ConButtons'}}" >{{{data.general.panic.icon}}} {{ localize 'ALIENRPG.Panicked'}} </h4>
@@ -215,6 +216,12 @@
                     
                   </div>
 
+                  <hr class="Item9">
+                  <span class="grid-2col-border">
+             	    <label class="   resource-label rollable" data-roll="{{data.general.armor.value}}" data-spbutt="armor">{{ localize "ALIENRPG.Armor"}}  </label>
+		            <input type="text" class="maxboxsize" name="data.general.armor.value"  value="{{data.general.armor.value}}" data-dtype="Number">
+                 </span>
+  
                 </div>
                 
                 <!-- Col 2 -->
@@ -248,40 +255,33 @@
         
         <div class="Item5">
           <label class="resource-label">{{ localize "ALIENRPG.SignatureItem"}}</label>
-          <textarea name="data.general.sigItem.value" rows="1"data-dtype="String">{{data.general.sigItem.value}}</textarea>
+          <input type="text" class="textbox" name="data.general.sigItem.value" value="{{data.general.sigItem.value}}"  rows="1"data-dtype="String"></textarea>
 
         </div>
         
         <div class="Item3">
           <label class="resource-label">{{ localize "ALIENRPG.PersonalAgenda"}}</label> 
-          <textarea name="data.general.agenda.value" rows="1"data-dtype="String">{{data.general.agenda.value}}</textarea>
+          <textarea name="data.general.agenda.value" rows="6"data-dtype="String">{{data.general.agenda.value}}</textarea>
         </div>
         
         <div class="Item6">
           <label class="resource-label">{{ localize "ALIENRPG.Relationships"}}</label> 
           <br>
           <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relOne"}}</label>
-          <textarea name="data.general.relOne.value" rows="1"data-dtype="String">{{data.general.relOne.value}}</textarea>
+          <input type="text" class="textbox" name="data.general.relOne.value" value="{{data.general.relOne.value}}" rows="1"data-dtype="String"></textarea>
+
+      
+          <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relTwo"}}</label>
+          <input type="text" class="textbox" name="data.general.relTwo.value"  value="{{data.general.relTwo.value}}" rows="1"data-dtype="String"></textarea>
 
         </div>
         
         <div class="Item7">
-          <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relTwo"}}</label>
-          <textarea name="data.general.relTwo.value" rows="1"data-dtype="String">{{data.general.relTwo.value}}</textarea>
-
-        </div>
-        
-        <div class="Item10">
           <label class="resource-label">{{ localize "ALIENRPG.CriticalInjuries"}}</label> 
           <textarea name="data.general.critInj.value" rows="2"data-dtype="String">{{data.general.critInj.value}}</textarea>
         </div>
         
-        <div class="Item11">
-          <span class="grid-2col">
-          <label class="   resource-label rollable" data-roll="{{data.general.armor.value}}" data-spbutt="armor">{{ localize "ALIENRPG.Armor"}}  </label>
-        <input type="text" class=" maxboxsize" name="data.general.armor.value"  value="{{data.general.armor.value}}" data-dtype="Number">
-      </span>
-      </div>
+       
   </div>
 
       </div>

--- a/templates/actor/synth-sheet.html
+++ b/templates/actor/synth-sheet.html
@@ -13,7 +13,7 @@
             <button class="plus-btn" data-pmbut="plusHealth"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
           </div>
           <h3>{{ localize "ALIENRPG.Synthetic"}}</h3>
-          <h3 style="text-align: center;">{{ localize "ALIENRPG.NoStress"}}</h3>
+        <h3 for="0" class="resource-label rollable" data-panicroll="0"data-mod="0">{{localize "ALIENRPG.NoStress"}}</h3>
 
       {{!-- Attributes --}}
       <div class="abilities grid-Char-Att">


### PR DESCRIPTION
List of all changes - these essentially just from the comments so you can identify the files affected by looking at them directly.

If you wish, please feel free to integrate and distribute these changes as per the Apache license. I would appreciate being credited for any contributions you decide to keep in your repository if you dont mind.   

Regards!

CHANGES in the PULL REQUEST

ENHANCEMENT- cause inventory to automatically calculate ammo weights as per Destroyer of Worlds
 (this version is a hack because it is hard coded to search for the word RPG in the class or weapon name.
ideally the Weapon Item would have an ammo weight member in the object itself.) The rule is 0.25 weight per load for all ammo, but 0.5 weight for RPGs.

ENHANCEMENT- slight reorganization on character sheet to show current panic value which is important for people to be able to reference for roleplaying, and make the Personal Agenda box easier to read.

ENHANCEMENT- Make SquareGrid calculate distances using euclidean distance to the nearest cm, rather than using Dungeons and Dragons 5e method. This makes it feel more like science fiction and less like a board game. This could be relatively easily turned into a setting, but there is no good reason not to use euclidean distance since distance calculations are not even part of the Alien game.

BUGFIX -Fix a bug where PUSHing a skill roll gives stress to the selected token rather than the original actor. Also other players could push skill rolls for characters they dont own - but they would take the stress.  Now there is 0 dependancy on any tokens.  the stress goes to the original actor that made the skill roll.

ENHANCEMENT- - actor.rollAbility(actor, {panicroll:1,mod:0}) should make a panic check, but synthetics could not invoke this. Now synthetics and characters can all make panic checks - synthetics never actually panic, but the result shows up as if they Keep it Together. not letting synthetics check for panic makes it obvious which actors are not human. TODO: modify synthetic sheet to turn 'stress' into a button - synth players can check with a macro however to keep up an illusion.

REFACTOR - removed a 60 lines of unnecessarily duplicated code. When someone rolls panic with modifiers, there is no reason to duplicate the entire code of the panic check, simply get the modifier from a dialog and invode the original actor.rollAbility(actor, {panicroll:1,mod:XXX}) function and pass the modifier rather than XXX.

ENHANCEMENT- when actors become panicked their Token now shows the 'fear.svg' overlay. When they stop being panicked their fear.svg overlay vanishes.  This only happens to tokens which are already in play in the current scene.  TODO maybe - check the value when dropping a token onto a scene and when changing scenes

BUGFIX - fixed a bug where skill checks were not properly respecting the visibility of rolls.  Skill rolls will now be private or whispered to the GM if those settings are selected in the Chat tab.



