### PR TITLE
Android Stress enhancement

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -243,5 +243,6 @@
   "ALIENRPG.CombatantUpdate": "更新演员",
   "ALIENRPG.CombatantReroll": "重新启动计划",
   "ALIENRPG.CombatantRemove": "删除演员",
-  "ALIENRPG.MultiPush": "允许多次推送"
+  "ALIENRPG.MultiPush": "允许多次推送",
+  "ALIENRPG.SynthStress": "Imitate Human Panic and Push Button"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -242,5 +242,6 @@
   "ALIENRPG.CombatantUpdate": "Schauspieler aktualisieren",
   "ALIENRPG.CombatantReroll": "ReRoll Initiative",
   "ALIENRPG.CombatantRemove": "Entfernen Sie Schauspieler",
-  "ALIENRPG.MultiPush": "Multi-Push zulassen"
+  "ALIENRPG.MultiPush": "Multi-Push zulassen",
+  "ALIENRPG.SynthStress": "Imitate Human Panic and Push Button"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -243,5 +243,7 @@
   "ALIENRPG.CombatantUpdate": "Update Actor",
   "ALIENRPG.CombatantReroll": "ReRoll Initiative",
   "ALIENRPG.CombatantRemove": "Remove Actor",
-  "ALIENRPG.MultiPush": "Allow multi-push"
+  "ALIENRPG.MultiPush": "Allow multi-push",
+  "ALIENRPG.SynthStress": "Imitate Human Panic and Push Button"
+
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -245,5 +245,6 @@
   "ALIENRPG.CombatantUpdate": "Actualizar actor",
   "ALIENRPG.CombatantReroll": "Iniciativa ReRoll",
   "ALIENRPG.CombatantRemove": "Eliminar actor",
-  "ALIENRPG.MultiPush": "Permitir empuje múltiple"
+  "ALIENRPG.MultiPush": "Permitir empuje múltiple",
+  "ALIENRPG.SynthStress": "Imitate Human Panic and Push Button"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -241,5 +241,7 @@
   "ALIENRPG.CombatantUpdate": "Mettre à jour l'acteur",
   "ALIENRPG.CombatantReroll": "Initiative ReRoll",
   "ALIENRPG.CombatantRemove": "Supprimer l'acteur",
-  "ALIENRPG.MultiPush": "Autoriser le multi-push"
+  "ALIENRPG.MultiPush": "Autoriser le multi-push",
+  "ALIENRPG.SynthStress": "Imitate Human Panic and Push Button"
+  
 }

--- a/lang/swe.json
+++ b/lang/swe.json
@@ -71,5 +71,6 @@
   "ALIENRPG.Officer": "Officer",
   "ALIENRPG.Pilot": "Pilot",
   "ALIENRPG.Roughneck": "Råskinnet",
-  "ALIENRPG.Scientist": "Forskare"
+  "ALIENRPG.Scientist": "Forskare",
+  "ALIENRPG.SynthStress": "Imitate Human Panic and Push Button"
 }

--- a/module/YZEDiceRoller.js
+++ b/module/YZEDiceRoller.js
@@ -3,7 +3,7 @@ export class yze {
    * YZEDice RollFunction.
    * Param for number of dice to roll for each die type/rolls
    * @param {Text} actor - Passed actor data
-   * @param {Text} hostile - Passed actor type
+   * @param {Text} actortype - Passed actor type
    * @param {Boolean} blind - True or False
    * @param {Boolean} reRoll - True or False
    * @param {Text} label - The skill/item being rolled against
@@ -24,11 +24,11 @@ export class yze {
    * let r1Data = parseInt(dataset.roll || 0);
    * let r2Data = this.actor.getRollData().stress;
    * let reRoll = false;
-   * yze.yzeRoll(hostile, blind, reRoll, label, r1Data, 'Black', r2Data, 'Yellow');
+   * yze.yzeRoll(actortype, blind, reRoll, label, r1Data, 'Black', r2Data, 'Yellow');
    *
    */
-  static async yzeRoll(hostile, blind, reRoll, label, r1Dice, col1, r2Dice, col2, actorid) {
-    // console.log('yze -> yzeRoll -> hostile, blind, reRoll, label, r1Dice, col1, r2Dice, col2', hostile, blind, reRoll, label, r1Dice, col1, r2Dice, col2);
+  static async yzeRoll(actortype, blind, reRoll, label, r1Dice, col1, r2Dice, col2, actorid) {
+    // console.log('yze -> yzeRoll -> actortype, blind, reRoll, label, r1Dice, col1, r2Dice, col2', actortype, blind, reRoll, label, r1Dice, col1, r2Dice, col2);
 
     // *******************************************************
     // Store the version number of FVTT
@@ -64,7 +64,7 @@ export class yze {
     // *******************************************************
     let rType = '';
     // if (reRoll && (hostile === true) === 'character') {
-    if ((reRoll && hostile === 'character') || reRoll === 'mPush') {
+    if ((reRoll && actortype === 'character') || reRoll === 'mPush') {
       rType = game.i18n.localize('ALIENRPG.Push');
     } else {
       rType = game.i18n.localize('ALIENRPG.Rolling');
@@ -131,8 +131,8 @@ export class yze {
       } else {
         let roll2 = `${r2Dice}` + 'ds';
         let com;
-        if (hostile === 'supply') {
-          // // console.log('yze -> yzeRoll -> hostile', hostile);
+        if (actortype === 'supply') {
+          // // console.log('yze -> yzeRoll -> actortype', actortype);
           com = `${roll2}`;
         } else {
           com = `${roll1}` + '+' + `${roll2}`;
@@ -154,7 +154,7 @@ export class yze {
       // *******************************************************
       // Display message if there is a 1> on the stress dice.  Display appropriate message if its a Supply roll.
       // *******************************************************
-      if (hostile != 'supply') {
+      if (actortype != 'supply') {
         if (game.alienrpg.rollArr.r2One >= 1) {
           chatMessage += '<div class="blink"; style="color: red; font-weight: bold; font-size: larger">' + game.i18n.localize('ALIENRPG.rollStress') + '</div>';
         }
@@ -180,7 +180,7 @@ export class yze {
       else return sTotal + ' ' + game.i18n.localize('ALIENRPG.sucesses');
     }
 
-    if (hostile != 'supply') {
+    if (actortype != 'supply') {
       chatMessage +=
         '<div style="color: #6868fc; font-weight: bold; font-size: larger">' +
         game.i18n.localize('ALIENRPG.youHave') +
@@ -192,7 +192,7 @@ export class yze {
     // *******************************************************
     //  If it's a Push roll and display the total for both rolls.
     // *******************************************************
-    if (reRoll && hostile === 'character') {
+    if (reRoll && actortype === 'character') {
       chatMessage +=
         '<hr>' +
         '<div style="color: #6868fc; font-weight: bold; font-size: larger">' +
@@ -203,7 +203,7 @@ export class yze {
         localizedCountOfSuccesses(oldRoll + game.alienrpg.rollArr.multiPush + game.alienrpg.rollArr.r1Six + game.alienrpg.rollArr.r2Six) +
         ' </div>';
       game.alienrpg.rollArr.multiPush = oldRoll;
-      console.log('spud');
+     // console.log('spud');
     }
 
     // *******************************************************
@@ -386,7 +386,7 @@ export class yze {
         }
         chatMessage += '</div>';
       } else {
-        if (hostile != 'supply') {
+        if (actortype != 'supply') {
           for (let index = 0; index < mr.terms[0].results.length; index++) {
             let spanner = flattenObj(mr.terms[0].results[index]);
             numbers.push(spanner.result);
@@ -414,7 +414,7 @@ export class yze {
           }
           chatMessage += '</div>';
         }
-        if (hostile === 'supply') {
+        if (actortype === 'supply') {
           for (let index = 0; index < mr.terms[0].results.length; index++) {
             let spanner = flattenObj(mr.terms[0].results[index]);
             numbers.push(spanner.result);

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -374,6 +374,7 @@ export class alienrpgActor extends Actor {
     let label = dataset.label;
     let r2Data = 0;
     let reRoll = false;
+    let effectiveActorType = actor.data.type ;
     game.alienrpg.rollArr.sCount = 0;
     game.alienrpg.rollArr.multiPush = 0;
 
@@ -391,12 +392,19 @@ export class alienrpgActor extends Actor {
       if (dataset.attr) {
         r1Data = parseInt(modifier);
       }
+        
+      reRoll = true;
+      r2Data = 0;
+        
       if (actor.data.type === 'character') {
         reRoll = false;
-        r2Data = actor.getRollData().stress + parseInt(stressMod );;
-      } else {
-        reRoll = true;
-        r2Data = 0;
+        r2Data = actor.getRollData().stress + parseInt(stressMod );
+      } else
+      if (actor.data.type === 'synthetic') {
+          if (actor.data.data.header.synthstress){
+            effectiveActorType='character'; // make rolls look human
+            reRoll = false;
+          }
       }
 
       let blind = false;
@@ -411,7 +419,7 @@ export class alienrpgActor extends Actor {
           blind = true;
       }
      
-      yze.yzeRoll(actor.data.data.type, blind, reRoll, label, r1Data, game.i18n.localize('ALIENRPG.Black'), r2Data, game.i18n.localize('ALIENRPG.Yellow'), actor.id);
+      yze.yzeRoll(effectiveActorType, blind, reRoll, label, r1Data, game.i18n.localize('ALIENRPG.Black'), r2Data, game.i18n.localize('ALIENRPG.Yellow'), actor.id);
       game.alienrpg.rollArr.sCount = game.alienrpg.rollArr.r1Six + game.alienrpg.rollArr.r2Six;
     } else {
       if (dataset.panicroll) {
@@ -436,6 +444,8 @@ export class alienrpgActor extends Actor {
         let aStress = 0;
 
         if (actor.data.type === 'synthetic') {
+            if (!actor.data.data.header.synthstress) return;
+            
           actor.data.data.header.stress = new Object({ mod: '0' });
           actor.data.data.general.panic = new Object({ lastRoll: '0', value: '0' });
           aStress = 0;

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -398,7 +398,7 @@ export class alienrpgActor extends Actor {
         reRoll = true;
         r2Data = 0;
       }
-      let hostile = actor.data.data.type;
+
       let blind = false;
       if (dataset.spbutt === 'armor' && r1Data < 1) {
         return;
@@ -408,11 +408,10 @@ export class alienrpgActor extends Actor {
         reRoll = true;
       }
       if (actor.data.token.disposition === -1) {
-        // hostile = true;
-        blind = true;
+          blind = true;
       }
      
-      yze.yzeRoll(hostile, blind, reRoll, label, r1Data, game.i18n.localize('ALIENRPG.Black'), r2Data, game.i18n.localize('ALIENRPG.Yellow'), actor.id);
+      yze.yzeRoll(actor.data.data.type, blind, reRoll, label, r1Data, game.i18n.localize('ALIENRPG.Black'), r2Data, game.i18n.localize('ALIENRPG.Yellow'), actor.id);
       game.alienrpg.rollArr.sCount = game.alienrpg.rollArr.r1Six + game.alienrpg.rollArr.r2Six;
     } else {
       if (dataset.panicroll) {

--- a/module/alienrpg.js
+++ b/module/alienrpg.js
@@ -372,9 +372,9 @@ Hooks.on('renderChatMessage', (message, html, data) => {
         if (actor.data.token.disposition === -1) {
           blind = true;
         }
-        if (actor.data.type != 'creature') {
+        if (actor.data.type == 'character') {
           actor.update({ 'data.header.stress.value': actor.data.data.header.stress.value + 1 });
-        }
+        } else return;
         const reRoll1 = game.alienrpg.rollArr.r1Dice - game.alienrpg.rollArr.r1Six;
         const reRoll2 = game.alienrpg.rollArr.r2Dice + 1 - (game.alienrpg.rollArr.r2One + game.alienrpg.rollArr.r2Six);
         yze.yzeRoll(hostile, blind, reRoll, game.alienrpg.rollArr.tLabel, reRoll1, game.i18n.localize('ALIENRPG.Black'), reRoll2, game.i18n.localize('ALIENRPG.Yellow'), actor.id);

--- a/template.json
+++ b/template.json
@@ -212,7 +212,8 @@
           "label": "Health",
           "max": 0
         },
-        "npc": false
+        "npc": false,
+        "synthstress":false
       },
       "attributes": {
         "str": {

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -268,7 +268,7 @@
           <label class="resource-label">{{ localize "ALIENRPG.Relationships"}}</label> 
           <br>
           <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relOne"}}</label>
-          <input type="text" class="textbox" name="data.general.relOne.value" value="{{data.general.relOne.value}}" rows="1"data-dtype="String"></textarea>
+          <input type="text" class="textbox" name="data.general.relOne.value" value="{{data.general.relOne.value}}" rows="1"data-dtype="String"></input>
 
       
           <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relTwo"}}</label>

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -8,15 +8,15 @@
         {{!-- Health and Stress --}}
           <h2 for="data.health.value" class="resource-label">{{ localize "ALIENRPG.Health"}}</h2>
           <div class="resource-content">
-            <button class="minus-btn" data-pmbut="minusHealth"><i class="fas fa-minus-square fa-xs" title="Minus"></i></button>
+            <button type="button" class="minus-btn" data-pmbut="minusHealth"><i class="fas fa-minus-square fa-xs" title="Minus"></i></button>
             <input type="text" class="maxboxsize" name="data.header.health.value" value="{{data.header.health.value}}" data-dtype="Number" />
-            <button class="plus-btn" data-pmbut="plusHealth"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
+            <button type="button" class="plus-btn" data-pmbut="plusHealth"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
           </div>
           <h2 for="data.header.stress.value" class="resource-label rollable" data-panicroll="{{data.header.stress.value}}"data-mod="{{data.header.stress.mod}}" data-label="{{localize "ALIENRPG.Stress"}}">{{localize "ALIENRPG.Stress"}}</h2>
           <div class="resource-content">
-            <button class="minus-btn" data-pmbut="minusStress"><i class="fas fa-minus-square fa-xs" title="Minus"></i></button>
+            <button type="button" class="minus-btn" data-pmbut="minusStress"><i class="fas fa-minus-square fa-xs" title="Minus"></i></button>
             <input type="text" class="maxboxsize" name="data.header.stress.value" value="{{data.header.stress.value}}" data-dtype="Number" />
-            <button class="plus-btn" data-pmbut="plusStress"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
+            <button type="button" class="plus-btn" data-pmbut="plusStress"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
       </div>
       {{!-- Attributes --}}
       <div class="abilities grid-Char-Att">
@@ -67,7 +67,7 @@
             <h3 for="data.skills.{{key}}.value" class="resource-label rollable Attr1" data-roll="{{skill.mod}}"  data-label="{{skill.label}}">{{skill.label}}  ({{skill.ability}})</h3>
             <input type="text" class="maxboxsize Attr2" name="data.skills.{{key}}.value" value="{{skill.value}}" data-dtype="Number" />
             <div class="resource-content">
-              <button class="stunt-btn Attr3" data-pmbut="{{skill.description}}"><i class="fas fa-tools fa-xs" title="Stunts"></i></button>
+              <button type="button" class="stunt-btn Attr3" data-pmbut="{{skill.description}}"><i class="fas fa-tools fa-xs" title="Stunts"></i></button>
             </div>
           </span>
           {{/each}}
@@ -192,25 +192,25 @@
                   <h3 class="Air1 resource-label">{{localize "ALIENRPG.Air"}}</h3>
                     <div class="resource-content">
                       <input type="text" class="maxboxsize" name="data.consumables.air.value" value="{{data.consumables.air.value}}" data-dtype="Number" />
-                      <button class="supply-btn Air2" data-spbutt="Air"  ><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
+                      <button type="button" class="supply-btn Air2" data-spbutt="Air"  ><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
                     </div>
                     
                   <h3 class="Food1 resource-label">{{localize "ALIENRPG.Food"}}</h3>
                     <div class="resource-content">
                       <input type="text" class="maxboxsize" name="data.consumables.food.value" value="{{data.consumables.food.value}}" data-dtype="Number" />
-                      <button class="supply-btn Food2" data-spbutt="Food" ><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
+                      <button type="button" class="supply-btn Food2" data-spbutt="Food" ><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
                     </div>
                     
                     <h3 class="Power1 resource-label">{{localize "ALIENRPG.Power"}}</h3>
                     <div class="resource-content">
                       <input type="text" class="maxboxsize" name="data.consumables.power.value" value="{{data.consumables.power.value}}" data-dtype="Number" />
-                      <button class="supply-btn Power2" data-spbutt="Power"><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
+                      <button type="button" class="supply-btn Power2" data-spbutt="Power"><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
                     </div>
                     
                     <h3 class="Water1 resource-label">{{localize "ALIENRPG.Water"}}</h3>
                     <div class="resource-content">
                       <input type="text" class="maxboxsize" name="data.consumables.water.value" value="{{data.consumables.water.value}}" data-dtype="Number" />
-                      <button class="supply-btn Water2" data-spbutt="Water"><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
+                      <button type="button" class="supply-btn Water2" data-spbutt="Water"><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
                     </div>
                     
                     

--- a/templates/actor/creature-sheet.html
+++ b/templates/actor/creature-sheet.html
@@ -61,7 +61,7 @@
           {{/each}} {{/select}}
         </select>
 
-        <button class="creature-attack-roll rTable2" data-atttype="{{data.rTables}}"></button>
+        <button type="button" class="creature-attack-roll rTable2" data-atttype="{{data.rTables}}"></button>
       </div>
       <h3 class="resource-label">{{localize "ALIENRPG.SpecialAbilities"}}</h3>
       <textarea name="data.general.special.value" rows="20" data-dtype="String">{{data.general.special.value}}</textarea>

--- a/templates/actor/synth-sheet.html
+++ b/templates/actor/synth-sheet.html
@@ -13,8 +13,11 @@
             <button class="plus-btn" data-pmbut="plusHealth"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
           </div>
           <h3>{{ localize "ALIENRPG.Synthetic"}}</h3>
+          {{#if data.header.synthstress}}
         <h3 for="0" class="resource-label rollable" data-panicroll="0"data-mod="0">{{localize "ALIENRPG.NoStress"}}</h3>
-
+         {{else}}
+         <h3 for="0" class="resource-label " data-panicroll="0"data-mod="0">{{localize "ALIENRPG.NoStress"}}</h3>
+         {{/if}}
       {{!-- Attributes --}}
       <div class="abilities grid-Char-Att">
 
@@ -145,6 +148,11 @@
                    {{!-- <span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}" >{{{data.general.radiation.icon}}} --}}
                   {{!-- </span> --}}
                 {{!-- </div> --}}
+           
+                     <h3 >{{localize "ALIENRPG.SynthStress"}}</h3>
+                      <input name="data.header.synthstress" type="checkbox" {{checked data.header.synthstress}} />
+                 
+                  
               </div>
         
               <div class="Item8">

--- a/templates/actor/synth-sheet.html
+++ b/templates/actor/synth-sheet.html
@@ -8,9 +8,9 @@
         {{!-- Health and Stress --}}
           <h2 for="data.health.value" class="resource-label">{{ localize "ALIENRPG.Health"}}</h2>
           <div class="resource-content">
-            <button class="minus-btn" data-pmbut="minusHealth"><i class="fas fa-minus-square fa-xs" title="Minus"></i></button>
+            <button type="button" type="button" class="minus-btn" data-pmbut="minusHealth"><i class="fas fa-minus-square fa-xs" title="Minus"></i></button>
             <input type="text" class="maxboxsize" name="data.header.health.value" value="{{data.header.health.value}}" data-dtype="Number" />
-            <button class="plus-btn" data-pmbut="plusHealth"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
+            <button type="button" class="plus-btn" data-pmbut="plusHealth"><i class="fas fa-plus-square fa-xs" title="Plus"></i></button>
           </div>
           <h3>{{ localize "ALIENRPG.Synthetic"}}</h3>
           {{#if data.header.synthstress}}
@@ -67,7 +67,7 @@
             <h3 for="data.skills.{{key}}.value" class="resource-label rollable Attr1" data-roll="{{skill.mod}}"  data-label="{{skill.label}}">{{skill.label}}  ({{skill.ability}})</h3>
             <input type="text" class="maxboxsize Attr2" name="data.skills.{{key}}.value" value="{{skill.value}}" data-dtype="Number" />
             <div class="resource-content">
-              <button class="stunt-btn Attr3" data-pmbut="{{skill.description}}"><i class="fas fa-tools fa-xs" title="Stunts"></i></button>
+              <button type="button" class="stunt-btn Attr3" data-pmbut="{{skill.description}}"><i class="fas fa-tools fa-xs" title="Stunts"></i></button>
             </div>
           </span>
           {{/each}}
@@ -168,7 +168,7 @@
                       <h3 class="Air1 resource-label">{{localize "ALIENRPG.Power"}}</h3>
                       <div class="resource-content">
                         <input type="text" class="maxboxsize" name="data.consumables.power.value" value="{{data.consumables.power.value}}" data-dtype="Number" />
-                        <button class="supply-btn Air2" data-spbutt="Power"><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
+                        <button type="button" class="supply-btn Air2" data-spbutt="Power"><i class="fas fa-parachute-box fa-xs" title="{{localize "ALIENRPG.Supply"}}"></i></button>
                       </div>
                     
                     

--- a/templates/actor/synth-sheet.html
+++ b/templates/actor/synth-sheet.html
@@ -174,6 +174,13 @@
                     
                </div>
 
+              <hr class="Item9">
+               <span class="grid-2col-border">
+                 <label class="   resource-label rollable" data-roll="{{data.general.armor.value}}" data-spbutt="armor">{{ localize "ALIENRPG.Armor"}}  </label>
+                 <input type="text" class="maxboxsize" name="data.general.armor.value"  value="{{data.general.armor.value}}" data-dtype="Number">
+              </span>
+              
+              
                 </div>
                 
                 <!-- Col 2 -->
@@ -208,32 +215,34 @@
         
         <div class="Item5">
           <label class="resource-label">{{ localize "ALIENRPG.PersonalAgenda"}}</label> 
-          <textarea name="data.general.agenda.value" rows="2"data-dtype="String">{{data.general.agenda.value}}</textarea>
+          <textarea name="data.general.agenda.value" rows="6"data-dtype="String">{{data.general.agenda.value}}</textarea>
         </div>
         
-        <div class="Item3">
+        <div class="Item6">
           <label class="resource-label">{{ localize "ALIENRPG.Relationships"}}</label> 
           <br>
           <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relOne"}}</label>
-          <textarea name="data.general.relOne.value" rows="1"data-dtype="String">{{data.general.relOne.value}}</textarea>
+          <input type="text" class="textbox" name="data.general.relOne.value"
+              value="{{data.general.relOne.value}}"
+              rows="1"data-dtype="String"></input>
+       
+          <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relTwo"}}</label>
+          <input type="text" class="textbox"  name="data.general.relTwo.value"
+              value="{{data.general.relTwo.value}}"
+              rows="1"data-dtype="String"></input>
         </div>
         
         <div class="Item7">
-          <label class="resource-label" style="font-size: smaller;">{{ localize "ALIENRPG.relTwo"}}</label>
-          <textarea name="data.general.relTwo.value" rows="1"data-dtype="String">{{data.general.relTwo.value}}</textarea>
-        </div>
-        
-        <div class="Item10">
           <label class="resource-label">{{ localize "ALIENRPG.CriticalInjuries"}}</label> 
           <textarea name="data.general.critInj.value" rows="2"data-dtype="String">{{data.general.critInj.value}}</textarea>
         </div>
         
-        <div class="Item11">
+     <!--    <div class="Item11">
           <span class="grid-2col">
           <label class="resource-label rollable" data-roll="{{data.general.armor.value}}" data-spbutt="armor">{{ localize "ALIENRPG.Armor"}}  </label>
         <input type="text" class=" maxboxsize" name="data.general.armor.value"  value="{{data.general.armor.value}}" data-dtype="Number">
       </span>
-      </div>
+      </div> -->
     </div>
 </div>
     </section>


### PR DESCRIPTION
slight code clean up replacing the variable 'hostile' with actortype.

Synthetics now control whether or not they can make fake panic rolls, or get a push button with an checkbox option on the character sheet to 'Imitate human stress and panic rolls'.   Open synthetics like Bishop or David or Working Joes turn it off and they wont panic even if rollAbility(panicroll) is executed.  Their skill rolls will not have a push button.

Secret synths can have it turned on, and they can make fake panic rolls (never rolling above 6) and their skill and ability rolls will have a push button just like human characters.  clicking push wont actually cause them to push. It just looks real. The HTML is identical as well.

In situations where a synthetic actively roleplays trying to avoid gaining stress, such as Ash who was hanging back on the Nostromo relaxing, they should be able to totally convincingly imitate a human actor.    A synth like Lucas would still need to use a human character sheet to gain stress dice.