### PR TITLE
adding combatant with high speed causes extra duplicates when there a…

### DIFF
--- a/module/alienrpg.js
+++ b/module/alienrpg.js
@@ -52,7 +52,7 @@ Hooks.on('createCombatant', (combat, combatant, options, someID) => {
     // actor type
 
     if (ACTOR.data.type != 'creature') return;
-    if (ACTOR.data.data.attributes?.speed?.value > 1) {
+    if ((ACTOR.data.data.attributes?.speed?.value > 1) && (game.user.isGM)) {
       const tokens = [];
       var x;
       for (x = 1; x < ACTOR.data.data.attributes.speed.value; x++) {


### PR DESCRIPTION
…re multiple players logged in due to every client reacting to the hooks.on.  only the GM's browser should add any extra combatants.  Fixed


- this is my fault for not testing with multiple users connected.  I got to experience this bug first hand tonight when a neomorph popped up with 7 initiatives :0  
