### PR TITLE
Criticals and $

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -98,6 +98,8 @@
     "DialTitle1": "投骰已修正",
     "DialTitle2": "检定",
     "Dice": "骰子: ",
+    "Dollar": "Add $",
+    "DollarNote": "Automatically add $ symbol after editing Cash or Cost",
     "DRAW": "画",
     "EditItem": "左键单击以进行编辑，右键单击以打开上下文菜单",
     "EditItemTitle": "修改物品",

--- a/lang/de.json
+++ b/lang/de.json
@@ -98,6 +98,8 @@
     "DialTitle1": "Wurf modifiziert",
     "DialTitle2": "probe",
     "Dice": "Würfel: ",
+    "Dollar": "Add $",
+    "DollarNote": "Automatically add $ symbol after editing Cash or Cost",
     "DRAW": "ziehen",
     "EditItem": "Linksklick zum Bearbeiten, Rechtsklick zum Öffnen des Kontextmenüs.",
     "EditItemTitle": "Objekt bearbeiten",

--- a/lang/en.json
+++ b/lang/en.json
@@ -98,6 +98,8 @@
     "DialTitle1": "Roll Modified",
     "DialTitle2": "check",
     "Dice": "Dice: ",
+    "Dollar": "Add $",
+    "DollarNote": "Automatically add $ symbol after editing Cash or Cost",
     "DRAW": "Draw",
     "EditItem": "Left Click to Edit, Right click to open context menu.",
     "EditItemTitle": "Edit Item",

--- a/lang/es.json
+++ b/lang/es.json
@@ -98,6 +98,8 @@
     "DialTitle1": "Tirada modificada",
     "DialTitle2": "Chequeo",
     "Dice": "Dado: ",
+    "Dollar": "Añadir $",
+    "DollarNote": "Añadira automaticamente el símbolo $ tras editar Dinero o Coste",
     "DRAW": "Dibujar",
     "EditItem": "Clic izquierdo para editar, clic derecho para abrir el menú contextual.",
     "EditItemTitle": "Editar Objeto",

--- a/lang/es.json
+++ b/lang/es.json
@@ -99,7 +99,7 @@
     "DialTitle2": "Chequeo",
     "Dice": "Dado: ",
     "Dollar": "Añadir $",
-    "DollarNote": "Añadira automaticamente el símbolo $ tras editar Dinero o Coste",
+    "DollarNote": "Añadir automaticamente el símbolo $ tras editar Dinero o Coste",
     "DRAW": "Dibujar",
     "EditItem": "Clic izquierdo para editar, clic derecho para abrir el menú contextual.",
     "EditItemTitle": "Editar Objeto",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -98,6 +98,8 @@
     "DialTitle1": "Test Modifié",
     "DialTitle2": "Vérifier",
     "Dice": "Dé: ",
+    "Dollar": "Add $",
+    "DollarNote": "Automatically add $ symbol after editing Cash or Cost",
     "DRAW": "Dessiner",
     "EditItem": "Clic gauche pour éditer, clic droit pour ouvrir le menu contextuel.",
     "EditItemTitle": "Editer Equipement",

--- a/lang/it.json
+++ b/lang/it.json
@@ -98,6 +98,8 @@
     "DialTitle1": "Tiro modificato",
     "DialTitle2": "tiro",
     "Dice": "Dadi: ",
+    "Dollar": "Add $",
+    "DollarNote": "Automatically add $ symbol after editing Cash or Cost",
     "DRAW": "Pesca",
     "EditItem": "Click col tasto sinistro per editare, click col tasto destro per aprire il menu di scelta rapida.",
     "EditItemTitle": "Modifica Oggetto",

--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -98,6 +98,8 @@
     "DialTitle1": "Modificar Rolagem de ",
     "DialTitle2": " Verifica",
     "Dice": "Dado(s): ",
+    "Dollar": "Add $",
+    "DollarNote": "Automatically add $ symbol after editing Cash or Cost",
     "DRAW": "Desenhar",
     "EditItem": "Clicar Botão Esquerdo para Editar ou Direito para abrir Menu.",
     "EditItemTitle": "Editar Item",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -98,6 +98,8 @@
     "DialTitle1": "擲骰已修正",
     "DialTitle2": "檢定",
     "Dice": "骰子: ",
+    "Dollar": "Add $",
+    "DollarNote": "Automatically add $ symbol after editing Cash or Cost",
     "DRAW": "画",
     "EditItem": "左键单击以进行编辑，右键单击以打开上下文菜单",
     "EditItemTitle": "修改物品",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1124,7 +1124,10 @@ export class alienrpgActorSheet extends ActorSheet {
     }
     function onBlur(e) {
       let value = localStringToNumber(e.target.value);
-      e.target.value = value ? Intl.NumberFormat('en-EN', { style: 'currency', currency: 'USD' }).format(value) : '';
+      if (game.settings.get('alienrpg', 'dollar'))
+         e.target.value = value ? Intl.NumberFormat('en-EN', { style: 'currency', currency: 'USD' }).format(value) : '0.00';
+      else
+         e.target.value = value ? Intl.NumberFormat('en-EN', { style: 'decimal', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value) : '0.00';
     }
   }
   async _onOverwatchToggle(event) {

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1115,7 +1115,10 @@ export class alienrpgActor extends Actor {
             case 'Yes ':
               cFatal = true;
               break;
-            case 'Yes, –1 ':
+            case 'Yes, -1 ':
+              cFatal = true;
+              break;
+            case 'Yes, -2 ':
               cFatal = true;
               break;
             default:
@@ -1136,9 +1139,8 @@ export class alienrpgActor extends Actor {
             case game.i18n.localize('ALIENRPG.OneShift') + ' ':
               healTime = 3;
               break;
-            case game.i18n.localize('ALIENRPG.OneDay'):
-              +' ';
-              healTime = 3;
+            case game.i18n.localize('ALIENRPG.OneDay') +' ':
+              healTime = 4;
               break;
             default:
               healTime = 0;

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -152,7 +152,10 @@ export class alienrpgItemSheet extends ItemSheet {
 
     function onBlur(e) {
       let value = e.target.value;
-      e.target.value = value ? Intl.NumberFormat('en-EN', { style: 'currency', currency: 'USD' }).format(value) : '';
+      if (game.settings.get('alienrpg', 'dollar'))
+         e.target.value = value ? Intl.NumberFormat('en-EN', { style: 'currency', currency: 'USD' }).format(value) : '0.00';
+      else
+         e.target.value = value ? Intl.NumberFormat('en-EN', { style: 'decimal', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value) : '0.00';
       // console.warn(e.target.value);
     }
   }

--- a/module/settings.js
+++ b/module/settings.js
@@ -171,6 +171,15 @@ export default function () {
       location.reload();
     },
   });
+  
+  game.settings.register('alienrpg', 'dollar', {
+    name: 'ALIENRPG.Dollar',
+    hint: 'ALIENRPG.DollarNote',
+    scope: 'world',
+    type: Boolean,
+    default: true,
+    config: true,
+  });
 
   game.settings.register('alienrpg', 'ARPGSemaphore', {
     name: 'Semaphore Flag',


### PR DESCRIPTION
Hi. Great job with the system.

This PR has two parts.

- Little fixes to critical injuries to make rolled criticals have correct data.
By the way, seems like the MU/TH/ER Instructions regarding this are a bit outdated.
- Making the $ symbol appear when editing Cash or Cost is very nice, but is incompatible with modules that look for a number there (like Item Piles). I created an option for the GM to choose if the $ is added or not.
Also made it write "0.00" instead of removing everything when an incorrect value (or 0) is written.