### PR TITLE
Campaign & Cinematic

### DIFF
--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -134,18 +134,38 @@
 
         <!-- Col1 -->
         <div class="Item1">
-          <h3 class="resource-label" style="font-weight: bold;">{{ localize 'ALIENRPG.XP'}}</h3>
-          <div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
-            <input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
-            <span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}
-            </span>
-          </div>
-          <br>
-          <h3 class="resource-label" style="font-weight: bold;">{{localize 'ALIENRPG.StoryPoints'}}</h3>
-          <div class="dots experience">
-            <input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
-            <span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
-          </div>
+		{{#if actor.system.general.xp.value}}
+		<div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
+		<h2 class="resource-label">{{localize 'ALIENRPG.campaign'}}</h2>
+		<br>
+			<div class="xp_dots_pos">
+				<h4 class="resource-label">{{ localize 'ALIENRPG.XP'}}</h4>
+				<input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
+				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}</span>
+			</div>
+		</div>
+		{{else if actor.system.general.sp.value}}
+		<div class="dots experience">
+		<h2 class="resource-label">{{localize 'ALIENRPG.cinematic'}}</h2>
+		<br>
+			<div class="xp_dots_pos">
+				<h4 class="resource-label">{{localize 'ALIENRPG.StoryPoints'}}</h4>
+				<input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
+				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
+			</div>
+		</div>
+		{{else}}
+		<div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
+			<h4 class="resource-label">{{ localize 'ALIENRPG.XP'}}</h4>
+			<input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
+			<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}</span>
+		</div>
+		<div class="dots experience sp_faded">
+			<h4 class="resource-label">{{localize 'ALIENRPG.StoryPoints'}}</h4>
+			<input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
+			<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
+		</div>
+		{{/if}}
           <br>
           <div style="margin-top: 6px;">
             <label class="resource-label">{{localize 'ALIENRPG.Cash'}}</label>

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -137,21 +137,22 @@
 		{{#if actor.system.general.xp.value}}
 		<div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
 		<h2 class="resource-label">{{localize 'ALIENRPG.campaign'}}</h2>
-		<br>
 			<div class="xp_dots_pos">
 				<h4 class="resource-label">{{ localize 'ALIENRPG.XP'}}</h4>
 				<input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
 				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}</span>
+			<br><br>
 			</div>
 		</div>
 		{{else if actor.system.general.sp.value}}
 		<div class="dots experience">
 		<h2 class="resource-label">{{localize 'ALIENRPG.cinematic'}}</h2>
-		<br>
 			<div class="xp_dots_pos">
+			<br>
 				<h4 class="resource-label">{{localize 'ALIENRPG.StoryPoints'}}</h4>
 				<input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
 				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
+			<br>
 			</div>
 		</div>
 		{{else}}

--- a/templates/actor/synthetic-sheet.html
+++ b/templates/actor/synthetic-sheet.html
@@ -139,21 +139,22 @@
 		{{#if actor.system.general.xp.value}}
 		<div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
 		<h2 class="resource-label">{{localize 'ALIENRPG.campaign'}}</h2>
-		<br>
 			<div class="xp_dots_pos">
 				<h4 class="resource-label">{{ localize 'ALIENRPG.XP'}}</h4>
 				<input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
 				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}</span>
+			<br><br>
 			</div>
 		</div>
 		{{else if actor.system.general.sp.value}}
 		<div class="dots experience">
 		<h2 class="resource-label">{{localize 'ALIENRPG.cinematic'}}</h2>
-		<br>
 			<div class="xp_dots_pos">
+			<br>
 				<h4 class="resource-label">{{localize 'ALIENRPG.StoryPoints'}}</h4>
 				<input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
 				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
+			<br>
 			</div>
 		</div>
 		{{else}}

--- a/templates/actor/synthetic-sheet.html
+++ b/templates/actor/synthetic-sheet.html
@@ -136,18 +136,38 @@
 
         <!-- Col1 -->
         <div class="Item1">
-          <h3 class="resource-label" style="font-weight: bold;">{{ localize 'ALIENRPG.XP'}}</h3>
-          <div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
-            <input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
-            <span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}
-            </span>
-          </div>
-          <br>
-          <h3 class="resource-label" style="font-weight: bold;">{{localize 'ALIENRPG.StoryPoints'}}</h3>
-          <div class="dots experience">
-            <input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
-            <span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
-          </div>
+		{{#if actor.system.general.xp.value}}
+		<div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
+		<h2 class="resource-label">{{localize 'ALIENRPG.campaign'}}</h2>
+		<br>
+			<div class="xp_dots_pos">
+				<h4 class="resource-label">{{ localize 'ALIENRPG.XP'}}</h4>
+				<input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
+				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}</span>
+			</div>
+		</div>
+		{{else if actor.system.general.sp.value}}
+		<div class="dots experience">
+		<h2 class="resource-label">{{localize 'ALIENRPG.cinematic'}}</h2>
+		<br>
+			<div class="xp_dots_pos">
+				<h4 class="resource-label">{{localize 'ALIENRPG.StoryPoints'}}</h4>
+				<input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
+				<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
+			</div>
+		</div>
+		{{else}}
+		<div class="dots experience" style="width: 150px; display: inline-flex;margin-bottom: 10px;">
+			<h4 class="resource-label">{{ localize 'ALIENRPG.XP'}}</h4>
+			<input type="hidden" name="system.general.xp.value" data-max="{{actor.system.general.xp.max}}" value="{{actor.system.general.xp.value}}" data-dtype="Number">
+			<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.xp.icon}}}</span>
+		</div>
+		<div class="dots experience sp_faded">
+			<h4 class="resource-label">{{localize 'ALIENRPG.StoryPoints'}}</h4>
+			<input type="hidden" name="system.general.sp.value" data-max="{{actor.system.general.sp.max}}" value="{{actor.system.general.sp.value}}" data-dtype="Number">
+			<span class="click-stat-level" title="{{ localize 'ALIENRPG.ConButtons'}}">{{{actor.system.general.sp.icon}}}</span>
+		</div>
+		{{/if}}
           <br>
           <div style="margin-top: 6px;">
             <label class="resource-label">{{localize 'ALIENRPG.Cash'}}</label>


### PR DESCRIPTION
The CRT sheet has a nice feature: When adding Experience or Story Points it shows the CAMPAIGN or CINEMATIC title and hides the other one. I ported it to the default sheet.

![AlienSheet](https://github.com/pwatson100/alienrpg/assets/87753744/938ea69c-4c17-4107-a218-2881c4e43e5a)

For character and synth sheets.