### PR TITLE
feat: Register yze-combat default settings

### DIFF
--- a/module/alienrpg.js
+++ b/module/alienrpg.js
@@ -493,6 +493,12 @@ Hooks.on('dropActorSheetData', async (actor, sheet, data) => {
 	}
 });
 
+// Register the settings for the Year Zero Engine: Combat module.
+Hooks.once('yzeCombatReady', yzec => yzec.register({
+	actorSpeedAttribute: 'system.attributes.speed.value',
+	duplicateCombatantOnCombatStart: true,
+}));
+
 function setupMacroFolders() {
 	if (!game.user.isGM) {
 		// Only make changes to system


### PR DESCRIPTION
This PR adds a hook trigger to register the default settings for the module **[Year Zero Engine: Combat](https://foundryvtt.com/packages/yze-combat)**.

The yze-combat method `.register()` will only register the settings if they are undefined.